### PR TITLE
Resolve missing text in Firefox (issues #14, #18)

### DIFF
--- a/sequences.js
+++ b/sequences.js
@@ -255,8 +255,7 @@ function initializeBreadcrumbTrail() {
     .attr("height", 150)
     //.attr('viewBox','0 0 '+Math.min(width,height)+' '+Math.min(width,height))
     //.attr('preserveAspectRatio','xMinYMin')
-    .attr("id", "trail")
-    .attr("transform", "translate(" + Math.min(width,height) / 2 + "," + Math.min(width,height) / 2 + ")");
+    .attr("id", "trail");
   // Add the label at the end, for the percentage.
   trail.append("svg:text")
     .attr("id", "endlabel")


### PR DESCRIPTION
In initializeBreadcrumbTrail, there was an extra transform() which was moving labels off the canvas for Firefox. 

Removing it made the labels appear in the expected place in Firefox.

Oddly, removing that transform() doesn't have much of an effect on Safari & Chrome, the labels are still in almost exactly the same place as before in those browsers.

Resolves #14, #18.
